### PR TITLE
Implement basic user CRUD support

### DIFF
--- a/TrinityBackendDjango/apps/accounts/serializers.py
+++ b/TrinityBackendDjango/apps/accounts/serializers.py
@@ -3,11 +3,16 @@ from .models import User, UserProfile
 
 
 class UserSerializer(serializers.ModelSerializer):
+    """Serializer for the custom User model with password handling."""
+
+    password = serializers.CharField(write_only=True, required=False)
+
     class Meta:
         model = User
         fields = [
             "id",
             "username",
+            "password",
             "email",
             "first_name",
             "last_name",
@@ -15,6 +20,25 @@ class UserSerializer(serializers.ModelSerializer):
             "preferences",
         ]
         read_only_fields = ["id"]
+
+    def create(self, validated_data):
+        password = validated_data.pop("password", None)
+        user = User(**validated_data)
+        if password:
+            user.set_password(password)
+        else:
+            user.set_unusable_password()
+        user.save()
+        return user
+
+    def update(self, instance, validated_data):
+        password = validated_data.pop("password", None)
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        if password:
+            instance.set_password(password)
+        instance.save()
+        return instance
 
 
 class UserProfileSerializer(serializers.ModelSerializer):

--- a/TrinityBackendDjango/apps/accounts/urls.py
+++ b/TrinityBackendDjango/apps/accounts/urls.py
@@ -1,11 +1,18 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import UserViewSet, UserProfileViewSet
+from .views import (
+    UserViewSet,
+    UserProfileViewSet,
+    LoginView,
+    LogoutView,
+)
 
 router = DefaultRouter()
 router.register(r"users", UserViewSet, basename="user")
 router.register(r"profiles", UserProfileViewSet, basename="userprofile")
 
 urlpatterns = [
+    path("login/", LoginView.as_view(), name="login"),
+    path("logout/", LogoutView.as_view(), name="logout"),
     path("", include(router.urls)),
 ]

--- a/TrinityBackendDjango/config/settings.py
+++ b/TrinityBackendDjango/config/settings.py
@@ -55,6 +55,9 @@ INSTALLED_APPS = SHARED_APPS + [
     app for app in TENANT_APPS if app not in SHARED_APPS
 ]
 
+# Custom user model
+AUTH_USER_MODEL = "accounts.User"
+
 # Specify tenant & domain models by app_label.ModelName
 TENANT_MODEL = "tenants.Tenant"
 TENANT_DOMAIN_MODEL = "tenants.Domain"

--- a/TrinityFrontend/src/App.tsx
+++ b/TrinityFrontend/src/App.tsx
@@ -14,6 +14,7 @@ import Workflow from "./pages/Workflow";
 import Laboratory from "./pages/Laboratory";
 import Exhibition from "./pages/Exhibition";
 import NotFound from "./pages/NotFound";
+import Users from "./pages/Users";
 
 const queryClient = new QueryClient();
 
@@ -54,6 +55,11 @@ const App = () => (
             <Route path="/exhibition" element={
               <ProtectedRoute>
                 <Exhibition />
+              </ProtectedRoute>
+            } />
+            <Route path="/users" element={
+              <ProtectedRoute>
+                <Users />
               </ProtectedRoute>
             } />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/TrinityFrontend/src/components/Header.tsx
+++ b/TrinityFrontend/src/components/Header.tsx
@@ -34,6 +34,10 @@ const Header = () => {
     navigate('/apps');
   };
 
+  const simpleHeader =
+    location.pathname.startsWith('/apps') ||
+    location.pathname.startsWith('/projects');
+
   return (
     <header className="bg-white border-b border-gray-200 px-8 py-4 flex items-center justify-between shadow-sm">
       <div className="flex items-center space-x-10">
@@ -50,42 +54,44 @@ const Header = () => {
           </div>
         </Link>
         
-        <nav className="flex items-center space-x-8">
-          <Link 
-            to="/workflow" 
-            className={`font-light text-sm transition-colors ${
-              location.pathname === '/workflow' 
-                ? 'text-trinity-blue border-b-2 border-trinity-blue pb-1' 
-                : 'text-gray-600 hover:text-trinity-blue'
-            }`}
-          >
-            Workflow
-          </Link>
-          <Link 
-            to="/laboratory" 
-            className={`font-light text-sm transition-colors ${
-              location.pathname === '/laboratory' 
-                ? 'text-trinity-blue border-b-2 border-trinity-blue pb-1' 
-                : 'text-gray-600 hover:text-trinity-blue'
-            }`}
-          >
-            Laboratory
-          </Link>
-          <Link 
-            to="/exhibition" 
-            className={`font-light text-sm transition-colors ${
-              location.pathname === '/exhibition' 
-                ? 'text-trinity-blue border-b-2 border-trinity-blue pb-1' 
-                : 'text-gray-600 hover:text-trinity-blue'
-            }`}
-          >
-            Exhibition
-          </Link>
-        </nav>
+        {!simpleHeader && (
+          <nav className="flex items-center space-x-8">
+            <Link
+              to="/workflow"
+              className={`font-light text-sm transition-colors ${
+                location.pathname === '/workflow'
+                  ? 'text-trinity-blue border-b-2 border-trinity-blue pb-1'
+                  : 'text-gray-600 hover:text-trinity-blue'
+              }`}
+            >
+              Workflow
+            </Link>
+            <Link
+              to="/laboratory"
+              className={`font-light text-sm transition-colors ${
+                location.pathname === '/laboratory'
+                  ? 'text-trinity-blue border-b-2 border-trinity-blue pb-1'
+                  : 'text-gray-600 hover:text-trinity-blue'
+              }`}
+            >
+              Laboratory
+            </Link>
+            <Link
+              to="/exhibition"
+              className={`font-light text-sm transition-colors ${
+                location.pathname === '/exhibition'
+                  ? 'text-trinity-blue border-b-2 border-trinity-blue pb-1'
+                  : 'text-gray-600 hover:text-trinity-blue'
+              }`}
+            >
+              Exhibition
+            </Link>
+          </nav>
+        )}
       </div>
 
       <div className="flex items-center space-x-4">
-        {projectName && (
+        {projectName && !simpleHeader && (
           <div className="flex items-center space-x-2 text-sm text-gray-600">
             <span>{projectName}</span>
             <button

--- a/TrinityFrontend/src/components/Header.tsx
+++ b/TrinityFrontend/src/components/Header.tsx
@@ -115,8 +115,10 @@ const Header = () => {
           <Settings className="w-4 h-4 text-gray-600" />
         </Button>
         
-        <Button variant="ghost" size="sm" className="p-2">
-          <User className="w-4 h-4 text-gray-600" />
+        <Button variant="ghost" size="sm" className="p-2" asChild>
+          <Link to="/users">
+            <User className="w-4 h-4 text-gray-600" />
+          </Link>
         </Button>
 
         <Button 

--- a/TrinityFrontend/src/components/Header.tsx
+++ b/TrinityFrontend/src/components/Header.tsx
@@ -91,7 +91,7 @@ const Header = () => {
             <button
               type="button"
               onClick={handleGoBack}
-              className="p-2 text-trinity-yellow hover:text-trinity-blue"
+              className="p-2 text-black"
               title="Go back to app menu"
             >
               <BackToAppsIcon className="w-5 h-5" />

--- a/TrinityFrontend/src/components/icons/BackToAppsIcon.tsx
+++ b/TrinityFrontend/src/components/icons/BackToAppsIcon.tsx
@@ -1,26 +1,15 @@
 import React from 'react';
+import { LogOut } from 'lucide-react';
 
 interface BackToAppsIconProps {
   className?: string;
 }
 
 const BackToAppsIcon: React.FC<BackToAppsIconProps> = ({ className = 'w-4 h-4' }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className={className}
-  >
-    <polyline points="10 8 6 12 10 16" />
-    <line x1="6" y1="12" x2="22" y2="12" />
-    <rect x="16" y="4" width="4" height="4" rx="1" />
-    <rect x="20" y="4" width="4" height="4" rx="1" />
-    <rect x="16" y="8" width="4" height="4" rx="1" />
-    <rect x="20" y="8" width="4" height="4" rx="1" />
-  </svg>
+  <LogOut
+    className={`${className} text-black`}
+    style={{ transform: 'scaleX(-1)' }}
+  />
 );
 
 export default BackToAppsIcon;

--- a/TrinityFrontend/src/contexts/AuthContext.tsx
+++ b/TrinityFrontend/src/contexts/AuthContext.tsx
@@ -1,34 +1,77 @@
 
 import React, { createContext, useContext, useState, useEffect } from 'react';
 
+interface UserInfo {
+  id: number;
+  username: string;
+  email: string;
+  mfa_enabled: boolean;
+  preferences: Record<string, unknown> | null;
+}
+
 interface AuthContextType {
   isAuthenticated: boolean;
-  login: () => void;
-  logout: () => void;
+  user: UserInfo | null;
+  login: (username: string, password: string) => Promise<boolean>;
+  logout: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+const API_BASE = "http://localhost:8000/api/accounts";
+
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [user, setUser] = useState<UserInfo | null>(null);
 
   useEffect(() => {
     const authState = localStorage.getItem('isAuthenticated');
-    setIsAuthenticated(authState === 'true');
+    if (authState === 'true') {
+      // check session
+      fetch(`${API_BASE}/users/me/`, { credentials: 'include' })
+        .then(async (res) => {
+          if (res.ok) {
+            const data = await res.json();
+            setUser(data);
+            setIsAuthenticated(true);
+          } else {
+            setIsAuthenticated(false);
+          }
+        })
+        .catch(() => setIsAuthenticated(false));
+    }
   }, []);
 
-  const login = () => {
-    localStorage.setItem('isAuthenticated', 'true');
-    setIsAuthenticated(true);
+  const login = async (username: string, password: string) => {
+    try {
+      const res = await fetch(`${API_BASE}/login/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ username, password }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setUser(data);
+        localStorage.setItem('isAuthenticated', 'true');
+        setIsAuthenticated(true);
+        return true;
+      }
+    } catch {
+      /* ignore */
+    }
+    return false;
   };
 
-  const logout = () => {
+  const logout = async () => {
+    await fetch(`${API_BASE}/logout/`, { method: 'POST', credentials: 'include' });
     localStorage.removeItem('isAuthenticated');
     setIsAuthenticated(false);
+    setUser(null);
   };
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+    <AuthContext.Provider value={{ isAuthenticated, user, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/TrinityFrontend/src/pages/Apps.tsx
+++ b/TrinityFrontend/src/pages/Apps.tsx
@@ -4,8 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Zap, BarChart3, Target, Plus, ChevronLeft, ChevronRight } from 'lucide-react';
-import AnimatedLogo from '@/components/AnimatedLogo';
-import LogoText from '@/components/LogoText';
+import Header from '@/components/Header';
 import AppCard from '@/components/AppList/AppCard';
 
 const Apps = () => {
@@ -89,29 +88,20 @@ const Apps = () => {
   return (
     <div className="min-h-screen bg-white flex flex-col">
 
-      {/* Header */}
+      <Header />
+
       <div className="relative z-10 p-8">
-        <div className="flex items-center space-x-4">
-          <AnimatedLogo className="w-12 h-12" />
-          <LogoText />
-        </div>
+        <Button
+          variant="ghost"
+          onClick={() => navigate('/projects')}
+          className="text-black hover:bg-trinity-yellow/10"
+        >
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          Back to Projects
+        </Button>
         <div className="mt-4">
-          <Button
-            variant="ghost"
-            onClick={() => navigate('/projects')}
-            className="text-black hover:bg-trinity-yellow/10"
-          >
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back to Projects
-          </Button>
-        </div>
-        <div className="mt-4">
-          <h1 className="text-3xl font-light text-black">
-            Choose Your Trinity App
-          </h1>
-          <p className="text-black/60 text-sm">
-            Select an application template to initialize
-          </p>
+          <h1 className="text-3xl font-light text-black">Choose Your Trinity App</h1>
+          <p className="text-black/60 text-sm">Select an application template to initialize</p>
         </div>
       </div>
 

--- a/TrinityFrontend/src/pages/Login.tsx
+++ b/TrinityFrontend/src/pages/Login.tsx
@@ -24,16 +24,13 @@ const Login = () => {
     setIsLoading(true);
     setError('');
 
-    // Simulate loading for better UX
-    await new Promise(resolve => setTimeout(resolve, 800));
-
-    if (username === 'username' && password === 'password') {
-      login();
+    const success = await login(username, password);
+    if (success) {
       navigate('/projects');
     } else {
-      setError('Invalid credentials. Please try again.');
+      setError('Invalid credentials.');
     }
-    
+
     setIsLoading(false);
   };
 

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -13,8 +13,7 @@ import {
   AlertDialogAction,
 } from '@/components/ui/alert-dialog';
 import { Plus, FolderOpen, Calendar, Pencil, Trash2 } from 'lucide-react';
-import AnimatedLogo from '@/components/AnimatedLogo';
-import LogoText from '@/components/LogoText';
+import Header from '@/components/Header';
 
 interface Project {
   id: string;
@@ -87,20 +86,11 @@ const Projects = () => {
   return (
     <div className="min-h-screen bg-white flex flex-col">
 
-      {/* Header */}
+      <Header />
+
       <div className="relative z-10 p-8">
-        <div className="flex items-center space-x-4">
-          <AnimatedLogo className="w-12 h-12" />
-          <LogoText />
-        </div>
-        <div className="mt-4">
-          <h1 className="text-3xl font-light text-black">
-            Trinity Projects
-          </h1>
-          <p className="text-black/60 text-sm">
-            Access your quantum matrices
-          </p>
-        </div>
+        <h1 className="text-3xl font-light text-black">Trinity Projects</h1>
+        <p className="text-black/60 text-sm">Access your quantum matrices</p>
       </div>
 
       {/* Main Content */}

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -144,9 +144,6 @@ const Projects = () => {
                       >
                         <Pencil className="w-4 h-4" />
                       </button>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <div className="w-2 h-2 bg-trinity-green rounded-full animate-pulse opacity-60"></div>
                       <AlertDialog
                         open={deleteId === project.id}
                         onOpenChange={(open) => {
@@ -175,12 +172,20 @@ const Projects = () => {
                           </AlertDialogHeader>
                           <AlertDialogFooter>
                             <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction onClick={() => deleteProject(project.id)}>
+                            <AlertDialogAction
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                deleteProject(project.id);
+                              }}
+                            >
                               Delete
                             </AlertDialogAction>
                           </AlertDialogFooter>
                         </AlertDialogContent>
                       </AlertDialog>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <div className="w-2 h-2 bg-trinity-green rounded-full animate-pulse opacity-60"></div>
                     </div>
                   </div>
                   

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -1,7 +1,18 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card } from '@/components/ui/card';
-import { Plus, FolderOpen, Calendar, Pencil } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
+import { Plus, FolderOpen, Calendar, Pencil, Trash2 } from 'lucide-react';
 import AnimatedLogo from '@/components/AnimatedLogo';
 import LogoText from '@/components/LogoText';
 
@@ -42,6 +53,7 @@ const Projects = () => {
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState('');
+  const [deleteId, setDeleteId] = useState<string | null>(null);
 
   const startRename = (e: React.MouseEvent, project: Project) => {
     e.stopPropagation();
@@ -63,6 +75,13 @@ const Projects = () => {
     setProjects(updated);
     localStorage.setItem('trinity-projects', JSON.stringify(updated));
     setEditingId(null);
+  };
+
+  const deleteProject = (id: string) => {
+    const updated = projects.filter((p) => p.id !== id);
+    setProjects(updated);
+    localStorage.setItem('trinity-projects', JSON.stringify(updated));
+    setDeleteId(null);
   };
 
   return (
@@ -126,7 +145,43 @@ const Projects = () => {
                         <Pencil className="w-4 h-4" />
                       </button>
                     </div>
-                    <div className="w-2 h-2 bg-trinity-green rounded-full animate-pulse opacity-60"></div>
+                    <div className="flex items-center space-x-2">
+                      <div className="w-2 h-2 bg-trinity-green rounded-full animate-pulse opacity-60"></div>
+                      <AlertDialog
+                        open={deleteId === project.id}
+                        onOpenChange={(open) => {
+                          if (!open) setDeleteId(null);
+                        }}
+                      >
+                        <AlertDialogTrigger asChild>
+                          <button
+                            type="button"
+                            className="p-1 text-red-500 hover:text-red-700"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDeleteId(project.id);
+                            }}
+                            title="Delete project"
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>Delete project?</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              This action cannot be undone.
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                            <AlertDialogAction onClick={() => deleteProject(project.id)}>
+                              Delete
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    </div>
                   </div>
                   
                   <div className="flex-1">

--- a/TrinityFrontend/src/pages/Users.tsx
+++ b/TrinityFrontend/src/pages/Users.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import Header from '@/components/Header';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface User {
+  id: number;
+  username: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  mfa_enabled: boolean;
+  preferences: Record<string, unknown> | null;
+}
+
+const API_BASE = 'http://localhost:8000/api/accounts';
+
+const Users = () => {
+  const [users, setUsers] = useState<User[]>([]);
+  const [form, setForm] = useState({ username: '', password: '', email: '' });
+
+  const loadUsers = async () => {
+    try {
+      const res = await fetch(`${API_BASE}/users/`);
+      if (res.ok) {
+        const data = await res.json();
+        setUsers(data);
+      }
+    } catch {
+      /* ignore errors for demo */
+    }
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`${API_BASE}/users/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        setForm({ username: '', password: '', email: '' });
+        await loadUsers();
+      }
+    } catch {
+      /* ignore errors for demo */
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+      <div className="max-w-3xl mx-auto p-8 space-y-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Create User</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <Input
+                name="username"
+                placeholder="Username"
+                value={form.username}
+                onChange={handleChange}
+              />
+              <Input
+                name="password"
+                type="password"
+                placeholder="Password"
+                value={form.password}
+                onChange={handleChange}
+              />
+              <Input
+                name="email"
+                type="email"
+                placeholder="Email"
+                value={form.email}
+                onChange={handleChange}
+              />
+              <Button type="submit">Add User</Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Existing Users</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {users.map((u) => (
+                <li key={u.id} className="border-b pb-1 last:border-none">
+                  {u.username} – {u.email}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default Users;

--- a/TrinityFrontend/src/pages/Users.tsx
+++ b/TrinityFrontend/src/pages/Users.tsx
@@ -22,7 +22,7 @@ const Users = () => {
 
   const loadUsers = async () => {
     try {
-      const res = await fetch(`${API_BASE}/users/`);
+      const res = await fetch(`${API_BASE}/users/`, { credentials: 'include' });
       if (res.ok) {
         const data = await res.json();
         setUsers(data);
@@ -46,6 +46,7 @@ const Users = () => {
       const res = await fetch(`${API_BASE}/users/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify(form),
       });
       if (res.ok) {

--- a/use_management_guide.txt
+++ b/use_management_guide.txt
@@ -1,0 +1,29 @@
+This guide explains how to run the user management stack with Docker and how to update endpoints.
+
+1. **Backend containers**
+   - Navigate to `TrinityBackendDjango`.
+   - Copy `.env.example` to `.env` and adjust database credentials if required.
+   - Run `docker compose up --build` to start Postgres, Mongo, Redis and the Django web service.
+   - The backend API will be available at `http://localhost:8000/`.
+
+2. **Frontend**
+   - Inside `TrinityFrontend`, install dependencies with `npm install` then run `npm start`.
+   - The React app proxies API requests to `localhost:8000` so both stacks must run concurrently.
+
+3. **Endpoints**
+   - User related API routes live in `TrinityBackendDjango/apps/accounts/urls.py`.
+   - Login: `POST /api/accounts/login/`
+   - Logout: `POST /api/accounts/logout/`
+   - Current user: `GET /api/accounts/users/me/`
+   - CRUD users: `/api/accounts/users/`
+
+4. **Updating the API base URL**
+   - Frontend requests use `http://localhost:8000/api/accounts` defined in `src/contexts/AuthContext.tsx` and `src/pages/Users.tsx`.
+   - Change this value if the backend runs on a different host or port.
+
+5. **Testing the flow**
+   - Start the backend with Docker and ensure migrations run (e.g. `docker compose exec web python manage.py migrate`).
+   - Create a superuser with `docker compose exec web python manage.py createsuperuser`.
+   - Access `http://localhost:3000/login` in the browser and log in with the created credentials.
+   - Navigate to the Users page via the header icon to view and create users.
+   - Use the logout button in the header to end the session.


### PR DESCRIPTION
## Summary
- handle password creation in `UserSerializer`
- add `/users` route for listing and creating users
- link user icon in header to the new user management page

## Testing
- `python TrinityBackendDjango/manage.py check`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684837a4b32c83219ab5b49c738fe83b